### PR TITLE
Deploy backup RPC to increase service availability

### DIFF
--- a/backup-rpc/README.md
+++ b/backup-rpc/README.md
@@ -43,7 +43,7 @@ Install and maintain RPC Archive node and open to public users for free.
 
 ## Relevant usage metrics
 
-- Provide RPC and Explorer service to 100k users.
+- Provide RPC service to 100k users.
 
 ## Competitors, peers, or similar projects
 

--- a/backup-rpc/README.md
+++ b/backup-rpc/README.md
@@ -1,0 +1,96 @@
+## Project name:
+
+Backup RPC: Install and maintain RPC Archive node and open to public users for free.
+
+## Author name and contact info
+
+(please provide a reliable point of contact for the project):
+
+1. Thanwa J. (thanwa.jdr@gmail.com)
+2. Nat W. (nat.wrw@gmail.com)
+
+I understand that I will be required to provide additional KYC information to the JIBChain to receive this grant:
+
+- [x] **Yes**
+- [ ] No
+
+## Recipient address:
+
+`0x00eb5682bCc49da2E7Cc20704813907229e4afD1`
+
+## Grant category:
+
+- [ ] DeFi
+- [ ] NFT
+- [ ] Tooling
+- [x] Other (Blockchain Infra struction)
+
+## Project description (please explain how your project works):
+
+Install and maintain RPC Archive node and open to public users for free.
+
+## Project links:
+
+- Will be announce once the proposal has been granted
+
+## Additional team member info (please link):
+
+- Cat Lab Team
+
+## Please link to any previous projects the team has meaningfully contributed to:
+
+- No
+
+## Relevant usage metrics
+
+- Provide RPC and Explorer service to 100k users.
+
+## Competitors, peers, or similar projects
+
+- domecloud-infra
+
+## Is/will this project be open sourced?
+
+- [x] Yes
+- [ ] No
+
+## Date of deployment/expected deployment on JIBChain:
+
+- Already deployed (https://jib-rpc.inan.in.th)
+
+## Ecosystem Value Proposition:
+
+What is the problem statement this proposal hopes to solve for the JIBChain ecosystem?
+
+- Backup RPC will help to reduce the risk of congestion and unstable. So, the user can use the service without any interruption.
+
+Has your project previously applied for an JBC grant? If successful, please link to your previous grant proposal and provide a brief update on milestones achieved with the grant. If unsuccessful, and this is a resubmission, please specify how you have incorporated significant changes in accordance with feedback.
+
+- No
+
+## Number of JBC tokens requested:
+
+- 100,000 JBC for the first year.
+
+## Did the project apply for or receive JBC tokens through the Foundation Partner Fund?:
+
+- [] Yes
+- [x] No (Individual)
+
+## If JBC tokens were requested from the Foundation Partner Fund, what was the amount?:
+
+- none
+
+## How much will your project match in co-incentives?
+
+(not required but recommended, when applicable): none
+
+## Proposal for token distribution:
+
+- Use for maintain the service by pay for cloud infrastructure.
+
+## KPI
+
+- Able to serve up to 100k users.
+- Service uptime 99.8%.
+- Service response time less than 1 second (average) in Thailand.

--- a/backup-rpc/README.md
+++ b/backup-rpc/README.md
@@ -57,6 +57,7 @@ Install and maintain RPC Archive node and open to public users for free.
 ## Date of deployment/expected deployment on JIBChain:
 
 - Already deployed (https://jib-rpc.inan.in.th)
+![image](https://github.com/nanthanwa/Grant-Proposal/assets/7475592/9a3df749-d908-497a-ae79-6704cad48e35)
 
 ## Ecosystem Value Proposition:
 
@@ -74,7 +75,7 @@ Has your project previously applied for an JBC grant? If successful, please link
 
 ## Did the project apply for or receive JBC tokens through the Foundation Partner Fund?:
 
-- [] Yes
+- [ ] Yes
 - [x] No (Individual)
 
 ## If JBC tokens were requested from the Foundation Partner Fund, what was the amount?:

--- a/backup-rpc/README.md
+++ b/backup-rpc/README.md
@@ -57,7 +57,7 @@ Install and maintain RPC Archive node and open to public users for free.
 ## Date of deployment/expected deployment on JIBChain:
 
 - Already deployed (https://jib-rpc.inan.in.th)
-![image](https://github.com/nanthanwa/Grant-Proposal/assets/7475592/9a3df749-d908-497a-ae79-6704cad48e35)
+  ![image](https://github.com/nanthanwa/Grant-Proposal/assets/7475592/9a3df749-d908-497a-ae79-6704cad48e35)
 
 ## Ecosystem Value Proposition:
 
@@ -88,7 +88,7 @@ Has your project previously applied for an JBC grant? If successful, please link
 
 ## Proposal for token distribution:
 
-- Use for maintain the service by pay for cloud infrastructure.
+- Use for maintain the service by pay for cloud infrastructure and stake JBC to create more validators.
 
 ## KPI
 

--- a/backup-rpc/README.md
+++ b/backup-rpc/README.md
@@ -1,6 +1,6 @@
 ## Project name:
 
-Backup RPC: Install and maintain RPC Archive node and open to public users for free.
+Backup RPC: Install and maintain RPC and Websocket of archive node and open to public users for free.
 
 ## Author name and contact info
 
@@ -27,7 +27,7 @@ I understand that I will be required to provide additional KYC information to th
 
 ## Project description (please explain how your project works):
 
-Install and maintain RPC Archive node and open to public users for free.
+Install and maintain RPC and Websocket of archive node and open to public users for free.
 
 ## Project links:
 


### PR DESCRIPTION
Hi, Granter

We are proposing a backup RPC to increase service availability.

Problem: User cannot interact with blockchain if the official RPC is down.
Our solution: Add alternative RPC that run full archive node as a backup RPC and registered with [https://chainlist.org](https://chainlist.org)

Please review this proposal and feel free to ask me on this thread.

- Thanwa